### PR TITLE
Implement simple weather telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Weather Telegram Bot
+
+This repository contains a simple Telegram bot that fetches current weather
+information using the OpenWeather API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the following environment variables:
+   - `TELEGRAM_TOKEN` – your Telegram bot token.
+   - `OPENWEATHER_TOKEN` – your OpenWeather API key.
+3. Run the bot:
+   ```bash
+   python weather_bot.py
+   ```
+
+Send `/weather <city>` to the bot to receive the current temperature and
+weather description for that city.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot==13.7
+requests

--- a/weather_bot.py
+++ b/weather_bot.py
@@ -1,0 +1,53 @@
+import os
+import logging
+import requests
+from telegram import Update
+from telegram.ext import Updater, CommandHandler, CallbackContext
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN")
+OPENWEATHER_TOKEN = os.environ.get("OPENWEATHER_TOKEN")
+
+if TELEGRAM_TOKEN is None:
+    raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+if OPENWEATHER_TOKEN is None:
+    raise RuntimeError("OPENWEATHER_TOKEN environment variable not set")
+
+def start(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(
+        "Hello! Send /weather <city> to get the current weather."
+    )
+
+def weather(update: Update, context: CallbackContext) -> None:
+    if not context.args:
+        update.message.reply_text("Usage: /weather <city>")
+        return
+    city = " ".join(context.args)
+    url = (
+        f"https://api.openweathermap.org/data/2.5/weather?q={city}&appid={OPENWEATHER_TOKEN}&units=metric"
+    )
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        temp = data["main"]["temp"]
+        description = data["weather"][0]["description"]
+        update.message.reply_text(f"Weather in {city}: {temp}°C, {description}")
+    except Exception as e:
+        logger.error("Failed to fetch weather", exc_info=e)
+        update.message.reply_text("Could not fetch weather data. Please try again.")
+
+def main() -> None:
+    updater = Updater(token=TELEGRAM_TOKEN)
+    dispatcher = updater.dispatcher
+    dispatcher.add_handler(CommandHandler("start", start))
+    dispatcher.add_handler(CommandHandler("weather", weather))
+
+    updater.start_polling()
+    logger.info("Bot started")
+    updater.idle()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a minimal Telegram bot in Python that queries the OpenWeather API
- document setup instructions in README
- add Python dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile weather_bot.py`
- `TELEGRAM_TOKEN=dummy OPENWEATHER_TOKEN=dummy python weather_bot.py` *(fails: InvalidToken)*

------
https://chatgpt.com/codex/tasks/task_e_684f2f944c4c832c90226695d715ec42